### PR TITLE
Fix&Refactor/Battle: 무승부 로직 연결, 스탯 저장되도록

### DIFF
--- a/Main_Project/Assets/BattleK/Scripts/AI/StaticAICore.cs
+++ b/Main_Project/Assets/BattleK/Scripts/AI/StaticAICore.cs
@@ -386,7 +386,6 @@ namespace BattleK.Scripts.AI
                     AiManager.UnregisterUnit(this);
                     if(Stat.InjuryLevel <= InjuryStatus.FatalInjury)
                         ++Stat.InjuryLevel;
-                    PersistUnitState();
                     AiManager.IsWinner();
                     break;
                 case DeathReason.System:
@@ -395,26 +394,8 @@ namespace BattleK.Scripts.AI
                 default:
                     throw new ArgumentOutOfRangeException(nameof(reason), reason, null);
             }
+            PersistUnitState();
             OverrideMachine.ChangeState(new StaticDeathState(this));
-
-            if (reason == DeathReason.System)
-            {
-                return;
-            }
-
-            if (!AiManager)
-            {
-                AiManager = AI_Manager.Instance;
-            }
-
-            if (!AiManager)
-            {
-                return;
-            }
-
-            AiManager.UnregisterUnit(this);
-            if (AiManager.IsAlreadyDone) return;
-            AiManager.IsWinner();
         }
 
         private void RegisterActionStates()
@@ -465,8 +446,7 @@ namespace BattleK.Scripts.AI
 
             Stat.SaveTo(unitData);
             //unitData.equippedItemId = Stat.Item != null ? Stat.Item.ItemId : null;
-
-            // TODO: EnemySaveManager 개편 시 실제 저장 메서드 연결
+            // TODO: EnemySaveManager 개편 시 실제 유닛 저장 메서드 연결
         }
         
 #if UNITY_EDITOR

--- a/Main_Project/Assets/BattleK/Scripts/Manager/AI_Manager.cs
+++ b/Main_Project/Assets/BattleK/Scripts/Manager/AI_Manager.cs
@@ -132,8 +132,8 @@ namespace BattleK.Scripts.Manager
                     Debug.Log("승리");
                     break;
                 case < 1 when enemyUnits.Count < 1:
+                    _leagueSceneManager.OnClickDraw();
                     Debug.Log("무승부");
-                    //ToDo:: 무승부되면 승, 패 없이 1점씩만 획득해야 함.
                     break;
             }
             IsAlreadyDone = true;

--- a/Main_Project/Assets/Scripts/Data/Enemy/EnemyTeamService.cs
+++ b/Main_Project/Assets/Scripts/Data/Enemy/EnemyTeamService.cs
@@ -175,11 +175,11 @@ public static class EnemyTeamService
 
     private static void AddSkill(Unit unit, SkillSO skill)
     {
-        if (unit.skills.Exists(s => s.skillId == skill.name)) return; 
+        /*if (unit.skills.Exists(s => s.skillId == skill.name)) return; 
         unit.skills.Add(new UnitSkill(skill.name, 1));
 
         if (!unit.selectedSkills.Contains(skill.name))  
-            unit.selectedSkills.Add(skill.name);
+            unit.selectedSkills.Add(skill.name);*/
     }
 
     // 획득 유닛 스킬 소급 부여


### PR DESCRIPTION
# 이름: 김경원
## 개발한 기능
- 없음

## 고친 버그 및 수정된 코드
- 무승부 로직 연결
- 적 팀 스탯 저장 가능하도록 준비

## 참고 자료
- 없음

## 리뷰가 필요한 부분
- @wonjiee 님의 EnemySaveManager를 사용하여 저장할 계획인데 유닛별 개별 저장이 되고 있는지, 된다면 어떻게 사용하면 되는지 궁금합니다. 현재 저는 사망 판정 기준으로 개별 저장할 계획이기에 일괄적으로 순회하는 것이 아닌 개별로 저장이 되어야 합니다.
- 스킬풀 역시 현재 skillId와 skillName도 통합되어있지 않고, 스킬풀을 저번에 개별로 분리하겠다고 하였기에 @wonjiee 님의 작업이 끝나면 작업하겠습니다.
- 무승부 로직은 연결해놓았습니다.
- 그리고 @jun3181 님이 OnDead쪽에서 안전검사를 많이 달아놓았던데 왜 이렇게 했는지 궁금합니다.

## 발견된 버그
- 없음
