### PR TITLE
군단병 도발 스킬 지속시간 버그 수정

### DIFF
--- a/Main_Project/Assets/BattleK/SO/Skills/3_Legionary/LGN_T3_1_Taunt.asset
+++ b/Main_Project/Assets/BattleK/SO/Skills/3_Legionary/LGN_T3_1_Taunt.asset
@@ -21,6 +21,8 @@ MonoBehaviour:
   SkillPrefabScale: 1
   FlipSkillPrefabByOwnerFacing: 0
   FollowSkillPrefab: 1
+  SkillPrefabSpawnCount: 1
+  SkillPrefabSpawnInterval: 0
   WindupPrefab: {fileID: 0}
   WindupSpawnAt: 0
   WindupPrefabScale: 1
@@ -28,13 +30,13 @@ MonoBehaviour:
   FadeWindupPrefab: 1
   WindupFadeInTime: 0.15
   WindupFadeOutTime: 0.15
-  Cooldown: 1
+  Cooldown: 7
   SkillArea: {x: 4, y: 4}
-  MaxHitTargets: 0
+  MaxHitTargets: 1
   OwnerFrontDistance: 1
   SpawnAt: 0
   WindupTime: 0
-  ActiveTime: 0.2
+  ActiveTime: 2
   RecoveryTime: 0
   SkillLogics:
   - rid: 7310100000000000002

--- a/Main_Project/Assets/BattleK/SO/Skills/3_Legionary/LGN_T3_2_AttackBuff.asset
+++ b/Main_Project/Assets/BattleK/SO/Skills/3_Legionary/LGN_T3_2_AttackBuff.asset
@@ -21,6 +21,8 @@ MonoBehaviour:
   SkillPrefabScale: 0.7
   FlipSkillPrefabByOwnerFacing: 0
   FollowSkillPrefab: 0
+  SkillPrefabSpawnCount: 1
+  SkillPrefabSpawnInterval: 0
   WindupPrefab: {fileID: 0}
   WindupSpawnAt: 0
   WindupPrefabScale: 1
@@ -34,7 +36,7 @@ MonoBehaviour:
   OwnerFrontDistance: 1
   SpawnAt: 1
   WindupTime: 0
-  ActiveTime: 1
+  ActiveTime: 5
   RecoveryTime: 0
   SkillLogics:
   - rid: 7300200000000000001
@@ -48,7 +50,7 @@ MonoBehaviour:
         _damageMultiplier: 1
         _flatBonusDamage: 0
         _hitCCData:
-          StatusName:
+          StatusName: 
           StatusType: 0
           duration: 0
           vfxPrefab: {fileID: 0}
@@ -58,4 +60,4 @@ MonoBehaviour:
           speedMultiplier: 1
     - rid: 7300200000000000002
       type: {class: NearestTargetLogic, ns: BattleK.Scripts.AI.Skill.Base.Logic.VerdictLogic, asm: Assembly-CSharp}
-      data:
+      data: 

--- a/Main_Project/Assets/BattleK/SO/Skills/3_Legionary/LGN_U_Invincible.asset
+++ b/Main_Project/Assets/BattleK/SO/Skills/3_Legionary/LGN_U_Invincible.asset
@@ -17,9 +17,11 @@ MonoBehaviour:
   SkillName: Legionary_U_Invincible
   InternalPriority: 500
   SkillPrefab: {fileID: 1063918882999393564, guid: 9b0326e5080f4cbe9f0e244c3154402d, type: 3}
-  SkillPrefabScale: 1
+  SkillPrefabScale: 0.3
   FlipSkillPrefabByOwnerFacing: 0
   FollowSkillPrefab: 1
+  SkillPrefabSpawnCount: 1
+  SkillPrefabSpawnInterval: 0
   WindupPrefab: {fileID: 0}
   WindupSpawnAt: 0
   WindupPrefabScale: 1

--- a/Main_Project/Assets/BattleK/Scenes/testbattle.unity
+++ b/Main_Project/Assets/BattleK/Scenes/testbattle.unity
@@ -170,6 +170,14 @@ PrefabInstance:
       propertyPath: Stat.Skills.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 6a945d3f10f6df148bd030ca2065b4e5, type: 2}
+    - target: {fileID: 7575697554110105575, guid: 970685f4bd681496e8de561ae617fe85, type: 3}
+      propertyPath: Stat.EquippedSkills.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575697554110105575, guid: 970685f4bd681496e8de561ae617fe85, type: 3}
+      propertyPath: Stat.EquippedSkills.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 761af5a731ce834458347b9e55d694ab, type: 2}
     - target: {fileID: 9066611189300349012, guid: 970685f4bd681496e8de561ae617fe85, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.75
@@ -638,7 +646,7 @@ MonoBehaviour:
   - {fileID: 1272870530}
   - {fileID: 866816324}
   _autoBattle: {fileID: 1030305002}
-  _autoStartOnPlay: 1
+  _autoStartOnPlay: 0
   _findSceneUnitsWhenTeamsAreEmpty: 1
   _setInitialTargets: 1
   _disableWinLoseFlowForSkillTest: 1
@@ -706,6 +714,33 @@ MonoBehaviour:
   enemyLayerName: Enemy
   forceLayerBySide: 1
   _leagueSceneManager: {fileID: 0}
+  _unitLoadManager: {fileID: 0}
+  _userSaveManager: {fileID: 0}
+  _league:
+    settings:
+      name: 
+      totalRounds: 0
+      pointRule:
+        win: 0
+        draw: 0
+        lose: 0
+      playerTeamId: 0
+      playerTeamName: 
+      tier: 0
+      tierName: 
+    teams: []
+    schedule: []
+    currentRound: 0
+    currentMatchIndex: 0
+    currentEnemyTeamId: 0
+    currentMatchId: 
+    currentEnemy:
+      id: 0
+      fid: 
+      name: 
+      money: 0
+      growthStage: 0
+      units: []
 --- !u!1 &1040406000
 GameObject:
   m_ObjectHideFlags: 0
@@ -878,6 +913,8 @@ Transform:
   - {fileID: 1974407165}
   - {fileID: 1272870529}
   - {fileID: 866816323}
+  - {fileID: 3001000004}
+  - {fileID: 3001000301}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1881500121
@@ -1208,6 +1245,485 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1408016855}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3001000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3001000004}
+  - component: {fileID: 3001000001}
+  - component: {fileID: 3001000002}
+  - component: {fileID: 3001000003}
+  m_Layer: 5
+  m_Name: TestBattleCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!223 &3001000001
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000000}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &3001000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &3001000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!224 &3001000004
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3001000104}
+  m_Father: {fileID: 1408016855}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &3001000100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3001000104}
+  - component: {fileID: 3001000101}
+  - component: {fileID: 3001000102}
+  - component: {fileID: 3001000103}
+  m_Layer: 5
+  m_Name: StartBattleButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &3001000101
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3001000102}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 174158991}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: SetInitialStats
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 174158991}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: Initialize
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1974407166}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: SetInitialStats
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1974407166}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: Initialize
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1272870530}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: SetInitialStats
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1272870530}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: Initialize
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 866816324}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: SetInitialStats
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 866816324}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.StaticAICore, Assembly-CSharp
+        m_MethodName: Initialize
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1020304002}
+        m_TargetAssemblyTypeName: BattleK.Scripts.AI.Skill.SkillExample.SkillExampleBattleStarter,
+          Assembly-CSharp
+        m_MethodName: BeginBattle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &3001000102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.12, g: 0.16, b: 0.19, a: 0.92}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 72cf6e32bdda88f488141685c5ba4d4a, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &3001000103
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000100}
+  m_CullTransparentMesh: 1
+--- !u!224 &3001000104
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000100}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3001000203}
+  m_Father: {fileID: 3001000004}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 130, y: -50}
+  m_SizeDelta: {x: 220, y: 56}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3001000200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3001000203}
+  - component: {fileID: 3001000201}
+  - component: {fileID: 3001000202}
+  m_Layer: 5
+  m_Name: StartBattleButtonLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &3001000201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Start Battle
+--- !u!222 &3001000202
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000200}
+  m_CullTransparentMesh: 1
+--- !u!224 &3001000203
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3001000104}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3001000300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3001000301}
+  - component: {fileID: 3001000302}
+  - component: {fileID: 3001000303}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3001000301
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000300}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1408016855}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3001000302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &3001000303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001000300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 5
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Main_Project/Assets/BattleK/Scripts/AI/Skill/Base/Logic/ExecuteLogic/TauntLogic.cs
+++ b/Main_Project/Assets/BattleK/Scripts/AI/Skill/Base/Logic/ExecuteLogic/TauntLogic.cs
@@ -9,6 +9,11 @@ namespace BattleK.Scripts.AI.Skill.Base.Logic.ExecuteLogic
         [SerializeField] private bool RestorePreviousTarget = true;
         [SerializeField] private bool RefreshDuration = true;
 
+        public float GetDuration()
+        {
+            return Mathf.Max(0f, Duration);
+        }
+
         public void Execute(StaticAICore owner, StaticAICore target)
         {
             if (!owner || !target) return;
@@ -21,7 +26,7 @@ namespace BattleK.Scripts.AI.Skill.Base.Logic.ExecuteLogic
                 controller = target.gameObject.AddComponent<TauntTargetController>();
             }
 
-            controller.Apply(owner, Duration, RestorePreviousTarget, RefreshDuration);
+            controller.Apply(owner, GetDuration(), RestorePreviousTarget, RefreshDuration);
         }
     }
 

--- a/Main_Project/Assets/BattleK/Scripts/AI/Skill/Base/SkillSO.cs
+++ b/Main_Project/Assets/BattleK/Scripts/AI/Skill/Base/SkillSO.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using BattleK.Scripts.AI.Skill.Base.Logic.ExecuteLogic;
 using BattleK.Scripts.AI.Skill.Base.Logic.LogicBase;
 using BattleK.Scripts.AI.Skill.Base.Projectile;
 using BattleK.Scripts.Utils;
@@ -72,14 +73,15 @@ namespace BattleK.Scripts.AI.Skill.Base
 
         public void ExecuteSkill(StaticAICore owner, Transform target)
         {
+            var activeTime = GetSkillActiveTime();
             var spawnCount = GetSkillPrefabSpawnCount();
             for (var i = 0; i < spawnCount; i++)
             {
-                SpawnSkillPrefab(owner, target);
+                SpawnSkillPrefab(owner, target, activeTime);
             }
         }
 
-        private GameObject SpawnSkillPrefab(StaticAICore owner, Transform target)
+        private GameObject SpawnSkillPrefab(StaticAICore owner, Transform target, float activeTime)
         {
             if (!SkillPrefab) return null;
             var spawnRot = owner.transform.rotation;
@@ -114,8 +116,13 @@ namespace BattleK.Scripts.AI.Skill.Base
             
             foreach (var p in processors)
             {
-                p.Initialize(owner, SkillLogics, ActiveTime, targetMask, target, spawnPos, MaxHitTargets);
+                p.Initialize(owner, SkillLogics, activeTime, targetMask, target, spawnPos, MaxHitTargets);
                 p.StartProcess();
+            }
+
+            if (processors.Length == 0)
+            {
+                Destroy(instance, activeTime);
             }
 
             return instance;
@@ -179,12 +186,13 @@ namespace BattleK.Scripts.AI.Skill.Base
         private IEnumerator SpawnSkillPrefabsRoutine(StaticAICore owner, Transform target)
         {
             var skillInstances = new List<GameObject>();
+            var activeTime = GetSkillActiveTime();
             var spawnCount = GetSkillPrefabSpawnCount();
             var spawnInterval = Mathf.Max(0f, SkillPrefabSpawnInterval);
 
             for (var i = 0; i < spawnCount; i++)
             {
-                var skillInstance = SpawnSkillPrefab(owner, target);
+                var skillInstance = SpawnSkillPrefab(owner, target, activeTime);
                 if (skillInstance)
                 {
                     skillInstances.Add(skillInstance);
@@ -198,11 +206,11 @@ namespace BattleK.Scripts.AI.Skill.Base
 
             if (FollowSkillPrefab && skillInstances.Count > 0)
             {
-                yield return FollowSkillPrefabsForActiveTime(skillInstances, owner, target);
+                yield return FollowSkillPrefabsForActiveTime(skillInstances, owner, target, activeTime);
                 yield break;
             }
 
-            yield return new WaitForSeconds(ActiveTime);
+            yield return new WaitForSeconds(activeTime);
         }
 
         private IEnumerator WaitForSkillPrefabSpawnInterval(float duration, List<GameObject> skillInstances, StaticAICore owner, Transform target)
@@ -222,10 +230,14 @@ namespace BattleK.Scripts.AI.Skill.Base
             }
         }
 
-        private IEnumerator FollowSkillPrefabsForActiveTime(List<GameObject> skillInstances, StaticAICore owner, Transform target)
+        private IEnumerator FollowSkillPrefabsForActiveTime(
+            List<GameObject> skillInstances,
+            StaticAICore owner,
+            Transform target,
+            float activeTime)
         {
             var elapsed = 0f;
-            while (elapsed < ActiveTime)
+            while (elapsed < activeTime)
             {
                 UpdateSkillPrefabFollows(skillInstances, owner, target);
                 elapsed += Time.deltaTime;
@@ -251,6 +263,22 @@ namespace BattleK.Scripts.AI.Skill.Base
         private int GetSkillPrefabSpawnCount()
         {
             return Mathf.Max(1, SkillPrefabSpawnCount);
+        }
+
+        private float GetSkillActiveTime()
+        {
+            var activeTime = Mathf.Max(0f, ActiveTime);
+            if (SkillLogics == null) return activeTime;
+
+            foreach (var logic in SkillLogics)
+            {
+                if (logic is TauntLogic tauntLogic)
+                {
+                    activeTime = Mathf.Max(activeTime, tauntLogic.GetDuration());
+                }
+            }
+
+            return activeTime;
         }
         
         public bool CanExecute(StaticAICore owner, out Transform foundTarget)

--- a/Main_Project/Assets/Ui/shader/Banner.mat
+++ b/Main_Project/Assets/Ui/shader/Banner.mat
@@ -71,7 +71,7 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaThreshold: 0
-    - _Angle: 53.358868
+    - _Angle: 152.46346
     - _BumpScale: 1
     - _ConnectedAlpha: 0
     - _Cutoff: 0.5

--- a/Main_Project/Assets/Ui/shader/RedBlue.mat
+++ b/Main_Project/Assets/Ui/shader/RedBlue.mat
@@ -71,7 +71,7 @@ Material:
     m_Ints: []
     m_Floats:
     - _AlphaThreshold: 0
-    - _Angle: 53.358868
+    - _Angle: 152.46346
     - _BumpScale: 1
     - _ConnectedAlpha: 0
     - _Cutoff: 0.5


### PR DESCRIPTION
# 이름: 김성준

## 개발한 기능

- 없음

## 고친 버그 및 수정된 코드

- 군단병 `Legionary_T3_1_Taunt` 스킬의 도발 지속시간이 의도보다 짧게 적용되던 문제를 수정했습니다.
- `TauntLogic`에서 도발 지속시간을 외부에서 확인할 수 있도록 `GetDuration()`을 추가했습니다.
- `SkillSO`에서 도발 로직이 포함된 스킬은 `ActiveTime`과 도발 지속시간 중 더 긴 시간을 기준으로 스킬 프리팹을 유지하도록 수정했습니다.
- 도발 스킬 프리팹이 너무 빨리 사라져 도발 적용 시간이 끊기는 문제를 방지했습니다.
- `LGN_T3_1_Taunt` 스킬 설정을 조정했습니다.
  - `Cooldown`: 1 → 7
  - `ActiveTime`: 0.2 → 2
  - `MaxHitTargets`: 0 → 1

## 참고 자료
없음

## 리뷰가 필요한 부분

- `SkillSO`에서 도발 지속시간을 기준으로 스킬 프리팹 유지 시간을 늘리는 방식이 다른 스킬 로직에 영향이 없는지 확인 부탁드립니다.

## 발견된 버그
- 없음